### PR TITLE
adds configurable resourcePath

### DIFF
--- a/lib/miniprofiler.js
+++ b/lib/miniprofiler.js
@@ -17,10 +17,11 @@
  var clientParser = require('./client-parser.js');
 
  const hostname = require('os').hostname;
-var ignoredPaths = [];
+ var ignoredPaths = [];
  var trivialDurationThresholdMilliseconds = 2.5;
  var popupShowTimeWithChildren = false;
  var popupRenderPosition = 'left';
+ var resourcePath = '/mini-profiler-resources/';
 
  exports.storage = {
   InMemoryStorage: require('./storages/inmemory.js'),
@@ -47,7 +48,6 @@ for (let framework of ['koa', 'express', 'hapi']) {
   exports[framework].for = func.buildMiddleware;
 }
 
-var resourcePath = '/mini-profiler-resources/';
 var version = require('../package.json').version;
 
 var contentTypes = {
@@ -218,6 +218,7 @@ function include(id) {
  *  - trivialDurationThresholdMilliseconds: double ; any step lasting longer than this will be considered trivial, and hidden by default
  *  - popupShowTimeWithChildren: boolean ; whether or not to include the "time with children" column
  *  - popupRenderPosition: 'left', 'right', 'bottomLeft', 'bottomRight' ; which side of the screen to display timings on
+ *  - resourcePath: string ; if your site root is in a subdirectory, specify here, e.g., /siteroot
  */
  function configure(options){
    options = options || {};
@@ -227,6 +228,7 @@ function include(id) {
    popupShowTimeWithChildren = options.popupShowTimeWithChildren || popupShowTimeWithChildren;
    popupRenderPosition = options.popupRenderPosition || popupRenderPosition;
    storage = options.storage || storage;
+   resourcePath = `${options.resourcePath || ''}/${resourcePath}`;
  }
 
 /*


### PR DESCRIPTION
This change allows you to modify the resourcePath with a subdirectory through configuration options:

` miniprofiler.configure({ resourcePath: '/myapproot' });
  app.use(miniprofiler.express());`

This allows miniprofiler resources to load if your app root is not /.